### PR TITLE
fix: use default imports for event-target-shim

### DIFF
--- a/src/MediaDevices.ts
+++ b/src/MediaDevices.ts
@@ -1,4 +1,4 @@
-import { EventTarget, Event, defineEventAttribute } from 'event-target-shim/index';
+import { EventTarget, Event, defineEventAttribute } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import getDisplayMedia from './getDisplayMedia';

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -1,4 +1,4 @@
-import { EventTarget, defineEventAttribute } from 'event-target-shim/index';
+import { EventTarget, defineEventAttribute } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import MediaStreamTrack, { MediaStreamTrackInfo } from './MediaStreamTrack';

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -1,4 +1,4 @@
-import { EventTarget, Event, defineEventAttribute } from 'event-target-shim/index';
+import { EventTarget, Event, defineEventAttribute } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import { MediaTrackConstraints } from './Constraints';

--- a/src/MediaStreamTrackEvent.ts
+++ b/src/MediaStreamTrackEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from 'event-target-shim/index';
+import { Event } from 'event-target-shim';
 
 import type MediaStreamTrack from './MediaStreamTrack';
 

--- a/src/MessageEvent.ts
+++ b/src/MessageEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from 'event-target-shim/index';
+import { Event } from 'event-target-shim';
 
 export type MessageEventData = string | ArrayBuffer | Blob;
 

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -1,5 +1,5 @@
 import * as base64 from 'base64-js';
-import { EventTarget, defineEventAttribute } from 'event-target-shim/index';
+import { EventTarget, defineEventAttribute } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import { addListener, removeListener } from './EventEmitter';

--- a/src/RTCDataChannelEvent.ts
+++ b/src/RTCDataChannelEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from 'event-target-shim/index';
+import { Event } from 'event-target-shim';
 
 import type RTCDataChannel from './RTCDataChannel';
 

--- a/src/RTCErrorEvent.ts
+++ b/src/RTCErrorEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from 'event-target-shim/index';
+import { Event } from 'event-target-shim';
 
 type RTCPeerConnectionErrorFunc =
     | 'addTransceiver'

--- a/src/RTCIceCandidateEvent.ts
+++ b/src/RTCIceCandidateEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from 'event-target-shim/index';
+import { Event } from 'event-target-shim';
 
 import type RTCIceCandidate from './RTCIceCandidate';
 

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -1,4 +1,4 @@
-import { EventTarget, Event, defineEventAttribute } from 'event-target-shim/index';
+import { EventTarget, Event, defineEventAttribute } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import { addListener, removeListener } from './EventEmitter';

--- a/src/RTCTrackEvent.ts
+++ b/src/RTCTrackEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from 'event-target-shim/index';
+import { Event } from 'event-target-shim';
 
 import MediaStream from './MediaStream';
 import type MediaStreamTrack from './MediaStreamTrack';


### PR DESCRIPTION
### Overview

Fixes the incorrect `'event-target-shim/index'` import. 
The version used by this library doesn't have an `index` entry point defined in the `package.json#exports` section.