### PR TITLE
fix: rare null activity when camera device is queried

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -195,8 +195,17 @@ class GetUserMediaImpl {
 
             Log.d(TAG, "getUserMedia(video): " + videoConstraintsMap);
 
+            Activity currentActivity = reactContext.getCurrentActivity();
+
+            if (currentActivity == null) {
+                // Fail with DOMException with name InvalidStateError as per:
+                // https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia
+                errorCallback.invoke("DOMException", "InvalidStateError");
+                return;
+            }
+
             CameraCaptureController cameraCaptureController =
-                    new CameraCaptureController(reactContext.getCurrentActivity(), getCameraEnumerator(), videoConstraintsMap);
+                    new CameraCaptureController(currentActivity, getCameraEnumerator(), videoConstraintsMap);
 
             videoTrack = createVideoTrack(cameraCaptureController);
         }


### PR DESCRIPTION
**Device info :**
OS version: android14
Model: Vivo I2202, Vivo Y200 5G
device states: background

**crash -**
```
          Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object android.content.Context.getSystemService(java.lang.String)' on a null object reference
       at com.oney.WebRTCModule.CameraCaptureController.updateActualSize(CameraCaptureController.java:222)
       at com.oney.WebRTCModule.CameraCaptureController.createVideoCapturer(CameraCaptureController.java:211)
       at com.oney.WebRTCModule.AbstractVideoCaptureController.initializeVideoCapturer(AbstractVideoCaptureController.java:38)
       at com.oney.WebRTCModule.GetUserMediaImpl.createVideoTrack(GetUserMediaImpl.java:374)
       at com.oney.WebRTCModule.GetUserMediaImpl.getUserMedia(GetUserMediaImpl.java:201)
       at com.oney.WebRTCModule.WebRTCModule.lambda$getUserMedia$11(WebRTCModule.java:777)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```