### PR TITLE
fix: once a track is cloned, remove the original reference

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -430,6 +430,9 @@ class GetUserMediaImpl {
         }
         clonedNativeTrack.setEnabled(nativeTrack.enabled());
         tracks.put(id, new TrackPrivate(clonedNativeTrack, track.mediaSource, track.videoCaptureController, track.surfaceTextureHelper));
+        // remove the original track reference
+        TrackPrivate track = tracks.remove(trackId);
+        nativeTrack.dispose();
         return clonedNativeTrack;
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -431,7 +431,7 @@ class GetUserMediaImpl {
         clonedNativeTrack.setEnabled(nativeTrack.enabled());
         tracks.put(id, new TrackPrivate(clonedNativeTrack, track.mediaSource, track.videoCaptureController, track.surfaceTextureHelper));
         // remove the original track reference
-        TrackPrivate track = tracks.remove(trackId);
+        tracks.remove(trackId);
         nativeTrack.dispose();
         return clonedNativeTrack;
     }

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -435,6 +435,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(mediaStreamTrackClone : (nonnull NSString
                 }
             }
         }
+        // remove the original track reference
+        [self.localTracks removeObjectForKey:trackID];
         return trackUUID;
     }
     return @"";


### PR DESCRIPTION
if we dont remove original reference then if stop is called the mediaSource that is shared is stopped

now after stop, the native code will do nothing as the reference is already removed