### PR TITLE
fix: don't dispose the mediaSource when disposing a cloned track

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -86,7 +86,9 @@ public abstract class AbstractVideoCaptureController {
 
     public boolean stopCapture() {
         try {
-            videoCapturer.stopCapture();
+            if (videoCapturer != null) {
+                videoCapturer.stopCapture();
+            }
             return true;
         } catch (InterruptedException e) {
             return false;

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -234,7 +234,9 @@ class GetUserMediaImpl {
             if (enabled) {
                 track.videoCaptureController.startCapture();
             } else {
-                track.videoCaptureController.stopCapture();
+                if (!track.isClone()) {
+                    track.videoCaptureController.stopCapture();
+                }
             }
         }
     }
@@ -530,7 +532,7 @@ class GetUserMediaImpl {
         }
 
         public void dispose() {
-            final boolean isClone = this.parent != null;
+            final boolean isClone = this.isClone();
             if (!disposed) {
                 if (!isClone && videoCaptureController != null) {
                     if (videoCaptureController.stopCapture()) {
@@ -561,6 +563,10 @@ class GetUserMediaImpl {
 
         public void setParent(TrackPrivate parent) {
             this.parent = parent;
+        }
+
+        public boolean isClone() {
+            return this.parent != null;
         }
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -419,17 +419,28 @@ class GetUserMediaImpl {
         if (track == null) {
             throw new IllegalArgumentException("No track found for id: " + trackId);
         }
+
         PeerConnectionFactory pcFactory = webRTCModule.mFactory;
+
         String id = UUID.randomUUID().toString();
         MediaStreamTrack nativeTrack = track.track;
-        MediaStreamTrack clonedNativeTrack;
+        final MediaStreamTrack clonedNativeTrack;
         if (nativeTrack instanceof VideoTrack) {
             clonedNativeTrack = pcFactory.createVideoTrack(id, (VideoSource) track.mediaSource);
         } else {
             clonedNativeTrack = pcFactory.createAudioTrack(id, (AudioSource) track.mediaSource);
         }
         clonedNativeTrack.setEnabled(nativeTrack.enabled());
-        tracks.put(id, new TrackPrivate(clonedNativeTrack, track.mediaSource, track.videoCaptureController, track.surfaceTextureHelper));
+
+        final TrackPrivate clone = new TrackPrivate(
+            clonedNativeTrack,
+            track.mediaSource,
+            track.videoCaptureController,
+            track.surfaceTextureHelper
+        );
+        clone.setParent(track);
+        tracks.put(id, clone);
+
         return clonedNativeTrack;
     }
 
@@ -495,6 +506,11 @@ class GetUserMediaImpl {
         private boolean disposed;
 
         /**
+         * Whether this object is a clone of another object.
+         */
+        private TrackPrivate parent = null;
+
+        /**
          * Initializes a new {@code TrackPrivate} instance.
          *
          * @param track
@@ -514,8 +530,9 @@ class GetUserMediaImpl {
         }
 
         public void dispose() {
+            final boolean isClone = this.parent != null;
             if (!disposed) {
-                if (videoCaptureController != null) {
+                if (!isClone && videoCaptureController != null) {
                     if (videoCaptureController.stopCapture()) {
                         videoCaptureController.dispose();
                     }
@@ -527,15 +544,23 @@ class GetUserMediaImpl {
                  * called. This also means that the caller can reuse the SurfaceTextureHelper to initialize a new
                  * VideoCapturer once the previous VideoCapturer has been disposed. */
 
-                if (surfaceTextureHelper != null) {
+                if (!isClone && surfaceTextureHelper != null) {
                     surfaceTextureHelper.stopListening();
                     surfaceTextureHelper.dispose();
                 }
 
-                mediaSource.dispose();
+                // clones should not dispose the mediaSource as that will affect the original track
+                // and other clones as well (since they share the same mediaSource).
+                if (!isClone) {
+                    mediaSource.dispose();
+                }
                 track.dispose();
                 disposed = true;
             }
+        }
+
+        public void setParent(TrackPrivate parent) {
+            this.parent = parent;
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.0.7",
+  "version": "125.0.8-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "125.0.7",
+      "version": "125.0.8-rc.1",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.0.8-rc.1",
+  "version": "125.0.8-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "125.0.8-rc.1",
+      "version": "125.0.8-rc.2",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.0.7",
+  "version": "125.0.8-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.0.8-rc.1",
+  "version": "125.0.8-rc.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"


### PR DESCRIPTION
### Overview

When disposing of a cloned track, we shouldn't dispose of the shared resources, as they'll lead to "blackened" root tracks.

`TrackPrivate` has been extended with an extra `parent` field that points to the parent track when cloned.
In the future, we should extend the implementation and ensure we properly clean up resources in both directions (top to bottom, and bottom-up). Currently, we only handle bottom-up.

Ref: https://linear.app/stream/issue/RN-168/issue-with-camera-not-turning-on-by-default-after-upgrading-sdk