### PR TITLE
feat: switch to Stream's WebRTC fork for iOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.1.0-rc.3",
+  "version": "125.1.0-rc.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "125.1.0-rc.3",
+      "version": "125.1.0-rc.4",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.0.8",
+  "version": "125.1.0-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "125.0.8",
+      "version": "125.1.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.0.8",
+  "version": "125.1.0-rc.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "125.1.0-rc.3",
+  "version": "125.1.0-rc.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"

--- a/stream-react-native-webrtc.podspec
+++ b/stream-react-native-webrtc.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.libraries           = 'c', 'sqlite3', 'stdc++'
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.dependency          'React-Core'
-  s.dependency          'StreamWebRTC', '~>125.6422.066'
+  s.dependency          'StreamWebRTC', '~>125.6422.070'
   # Swift/Objective-C compatibility #https://blog.cocoapods.org/CocoaPods-1.5.0/
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES'

--- a/stream-react-native-webrtc.podspec
+++ b/stream-react-native-webrtc.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.libraries           = 'c', 'sqlite3', 'stdc++'
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.dependency          'React-Core'
-  s.dependency          'WebRTC-SDK', '~>125.6422.07'
+  s.dependency          'StreamWebRTC', '~>125.6422.066'
   # Swift/Objective-C compatibility #https://blog.cocoapods.org/CocoaPods-1.5.0/
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES'


### PR DESCRIPTION
### Overview

Switches the underlying WebRTC native layer to our own fork: https://github.com/GetStream/stream-video-swift-webrtc

We currently do this for iOS only. We can't switch the Android one as that would require bumping the minimum Kotlin version support for our RN SDK and at this moment we can't do so.