### PR TITLE
fix: android screensharing issues on new arch

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -1,9 +1,12 @@
 package com.oney.WebRTCModule;
 
 import android.app.Activity;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ServiceConnection;
 import android.media.projection.MediaProjectionManager;
+import android.os.IBinder;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import androidx.core.util.Consumer;
@@ -59,6 +62,20 @@ class GetUserMediaImpl {
     private Promise displayMediaPromise;
     private Intent mediaProjectionPermissionResultData;
 
+    private final ServiceConnection mediaProjectionServiceConnection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            // Service is now bound, you can call createScreenStream()
+            Log.d(TAG, "MediaProjectionService bound, creating screen stream.");
+            createScreenStream();
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            Log.d(TAG, "MediaProjectionService disconnected.");
+        }
+    };
+
     GetUserMediaImpl(WebRTCModule webRTCModule, ReactApplicationContext reactContext) {
         this.webRTCModule = webRTCModule;
         this.reactContext = reactContext;
@@ -77,8 +94,7 @@ class GetUserMediaImpl {
                     mediaProjectionPermissionResultData = data;
 
                     ThreadUtils.runOnExecutor(() -> {
-                        MediaProjectionService.launch(activity);
-                        createScreenStream();
+                        MediaProjectionService.launch(activity, mediaProjectionServiceConnection);
                     });
                 }
             }

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -67,7 +67,9 @@ class GetUserMediaImpl {
         public void onServiceConnected(ComponentName name, IBinder service) {
             // Service is now bound, you can call createScreenStream()
             Log.d(TAG, "MediaProjectionService bound, creating screen stream.");
-            createScreenStream();
+            ThreadUtils.runOnExecutor(() -> {
+                createScreenStream();
+            });
         }
 
         @Override
@@ -93,9 +95,8 @@ class GetUserMediaImpl {
 
                     mediaProjectionPermissionResultData = data;
 
-                    ThreadUtils.runOnExecutor(() -> {
-                        MediaProjectionService.launch(activity, mediaProjectionServiceConnection);
-                    });
+                    MediaProjectionService.launch(activity, mediaProjectionServiceConnection);
+
                 }
             }
         });

--- a/android/src/main/java/com/oney/WebRTCModule/MediaProjectionNotification.java
+++ b/android/src/main/java/com/oney/WebRTCModule/MediaProjectionNotification.java
@@ -61,13 +61,12 @@ class MediaProjectionNotification {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, ONGOING_CONFERENCE_CHANNEL_ID);
 
         builder
-                .setCategory(NotificationCompat.CATEGORY_CALL)
                 .setContentTitle(context.getString(R.string.media_projection_notification_title))
                 .setContentText(context.getString(R.string.media_projection_notification_text))
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                .setOngoing(false)
-                .setUsesChronometer(false)
-                .setAutoCancel(true)
+                .setOngoing(true)
+                .setSilent(true)
+                .setWhen(System.currentTimeMillis())
+                .setAutoCancel(false)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setOnlyAlertOnce(true)
                 .setSmallIcon(context.getResources().getIdentifier("ic_notification", "drawable", context.getPackageName()))

--- a/android/src/main/java/com/oney/WebRTCModule/MediaProjectionService.java
+++ b/android/src/main/java/com/oney/WebRTCModule/MediaProjectionService.java
@@ -1,11 +1,14 @@
 package com.oney.WebRTCModule;
 
+import android.app.Activity;
 import android.app.Notification;
 import android.app.Service;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ServiceConnection;
 import android.content.pm.ServiceInfo;
+import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
@@ -23,22 +26,30 @@ import java.util.Random;
 public class MediaProjectionService extends Service {
     private static final String TAG = MediaProjectionService.class.getSimpleName();
 
-    static final int NOTIFICATION_ID = new Random().nextInt(99999) + 10000;
+    private final IBinder binder = new LocalBinder();
 
-    public static void launch(Context context) {
+    public class LocalBinder extends Binder {
+        public MediaProjectionService getService() {
+            // Return this instance of MediaProjectionService so clients can call public methods
+            return MediaProjectionService.this;
+        }
+    }
+
+    public static void launch(Activity activity, ServiceConnection serviceConnection) {
         if (!WebRTCModuleOptions.getInstance().enableMediaProjectionService) {
             return;
         }
 
-        MediaProjectionNotification.createNotificationChannel(context);
-        Intent intent = new Intent(context, MediaProjectionService.class);
+        MediaProjectionNotification.createNotificationChannel(activity);
+        Intent intent = new Intent(activity, MediaProjectionService.class);
+        activity.bindService(intent, serviceConnection, Context.BIND_IMPORTANT);
         ComponentName componentName;
 
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                componentName = context.startForegroundService(intent);
+                componentName = activity.startForegroundService(intent);
             } else {
-                componentName = context.startService(intent);
+                componentName = activity.startService(intent);
             }
         } catch (RuntimeException e) {
             // Avoid crashing due to ForegroundServiceStartNotAllowedException (API level 31).
@@ -65,7 +76,7 @@ public class MediaProjectionService extends Service {
 
     @Override
     public IBinder onBind(Intent intent) {
-        return null;
+        return binder;
     }
 
     @Override
@@ -73,10 +84,12 @@ public class MediaProjectionService extends Service {
 
         Notification notification = MediaProjectionNotification.buildMediaProjectionNotification(this);
 
+        final int id = (int) (System.currentTimeMillis() % Integer.MAX_VALUE);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
+            startForeground(id, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
         } else {
-            startForeground(NOTIFICATION_ID, notification);
+            startForeground(id, notification);
         }
 
         return START_NOT_STICKY;

--- a/android/src/main/java/com/oney/WebRTCModule/MediaProjectionService.java
+++ b/android/src/main/java/com/oney/WebRTCModule/MediaProjectionService.java
@@ -84,7 +84,8 @@ public class MediaProjectionService extends Service {
 
         Notification notification = MediaProjectionNotification.buildMediaProjectionNotification(this);
 
-        final int id = (int) (System.currentTimeMillis() % Integer.MAX_VALUE);
+        final Random random = new Random();
+        final int id = random.nextInt(Integer.MAX_VALUE);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(id, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);


### PR DESCRIPTION
Screenshare track was seen as black empty track when shared from android 

**Cause**: Screenshare stream must be created after the foreground service was started. There was no reliable waiting mechanism before. So if we did not wait, the stream was blank

**Fix**: we use android service binder, to wait until the service has started.  Also now generates a new notification ID on every screenshare notification, Previously since same id was used, it was not being posted on second try.

## Screenshot from new arch now seen from pronto web

<img width="1722" alt="image" src="https://github.com/user-attachments/assets/ab75b88a-0e4a-4dae-b2a3-3be93ca42a81" />
