### PR TITLE
fix: fixed dict and array enumeration for clone method

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -519,9 +519,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(mediaStreamTrackClone : (nonnull NSString
             RTCAudioTrack *audioTrack = [self.peerConnectionFactory audioTrackWithTrackId:trackUUID];
             audioTrack.isEnabled = originalTrack.isEnabled;
             [self.localTracks setObject:audioTrack forKey:trackUUID];
-            for (NSString* streamId in self.localStreams) {
+            for (NSString* streamId in [self.localStreams allKeys]) {
                 RTCMediaStream* stream = [self.localStreams objectForKey:streamId];
-                for (RTCAudioTrack* track in stream.audioTracks) {
+                if (stream == nil) continue;
+                for (RTCAudioTrack* track in [stream.audioTracks copy]) {
                     if ([trackID isEqualToString:track.trackId]) {
                         [stream addAudioTrack:audioTrack];
                     }
@@ -537,9 +538,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(mediaStreamTrackClone : (nonnull NSString
             [self addLocalVideoTrackDimensionDetection:videoTrack];
             
             [self.localTracks setObject:videoTrack forKey:trackUUID];
-            for (NSString* streamId in self.localStreams) {
+            for (NSString* streamId in [self.localStreams allKeys]) {
                 RTCMediaStream* stream = [self.localStreams objectForKey:streamId];
-                for (RTCVideoTrack* track in stream.videoTracks) {
+                if (stream == nil) continue;
+                for (RTCVideoTrack* track in [stream.videoTracks copy]) {
                     if ([trackID isEqualToString:track.trackId]) {
                         [stream addVideoTrack:videoTrack];
                     }


### PR DESCRIPTION
###   The Problem

  The clone method on iOS has two mutation-during-enumeration bugs — a classic Objective-C pitfall that causes crashes:

  1. Dictionary mutation during enumeration — The code iterates over self.localStreams directly (for ... in self.localStreams) while the loop body can modify the
  dictionary (e.g., adding tracks to a stream can trigger side effects). In Objective-C, mutating a collection while enumerating it throws an NSInvalidArgumentException.
  2. Array mutation during enumeration — Similarly, stream.audioTracks and stream.videoTracks are iterated directly, but addAudioTrack: / addVideoTrack: calls inside the
  loop can mutate the underlying array.

###   The Fix (two changes, applied to both audio and video track cloning)

  Before: for (... in self.localStreams)
  After: for (... in [self.localStreams allKeys])
  Why: Iterates over a snapshot of the dictionary keys, so mutations to the dictionary during the loop are safe.
  ────────────────────────────────────────
  Before: for (... in stream.audioTracks) / stream.videoTracks
  After: for (... in [stream.audioTracks copy]) / [stream.videoTracks copy]
  Why: Iterates over a copy of the array, so adding tracks to the stream mid-loop won't crash.
  ────────────────────────────────────────
  Before: (no nil check)
  After: if (stream == nil) continue;
  Why: Adds a defensive nil guard in case a stream was removed between getting the keys and looking it up.

###   Impact

  This is a crash fix for the iOS track cloning path. Without it, cloning a media stream track could intermittently crash the app with a "collection was mutated while
  being enumerated" exception — a race condition that's hard to reproduce but common under load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of media stream handling to prevent potential issues during track operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->