### PR TITLE
chore: cleanup for android on bridge reload

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -356,7 +356,13 @@ public class GetUserMediaImpl {
 
     private void createScreenStream() {
         // Guards against onServiceConnected firing after invalidate() has disposed and nulled mFactory.
-        if (webRTCModule.mFactory == null) return;
+        if (webRTCModule.mFactory == null) {
+            if (displayMediaPromise != null) {
+                displayMediaPromise.reject("ERR_MODULE_DISPOSED", "WebRTCModule disposed during getDisplayMedia");
+                displayMediaPromise = null;
+            }
+            return;
+        }
         VideoTrack track = createScreenTrack();
 
         if (track == null) {

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -285,6 +285,17 @@ public class GetUserMediaImpl {
         }
     }
 
+    void disposeAllTracks() {
+        for (Map.Entry<String, TrackPrivate> entry : tracks.entrySet()) {
+            try {
+                entry.getValue().dispose();
+            } catch (Exception e) {
+                Log.w(TAG, "disposeAllTracks: error disposing " + entry.getKey(), e);
+            }
+        }
+        tracks.clear();
+    }
+
     void disposeTrack(String id) {
         TrackPrivate track = tracks.remove(id);
         if (track != null) {
@@ -344,6 +355,8 @@ public class GetUserMediaImpl {
     }
 
     private void createScreenStream() {
+        // Guards against onServiceConnected firing after invalidate() has disposed and nulled mFactory.
+        if (webRTCModule.mFactory == null) return;
         VideoTrack track = createScreenTrack();
 
         if (track == null) {

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -633,9 +633,10 @@ public class GetUserMediaImpl {
                     }
                 }
 
-                // Clean up VideoTrackAdapter for video tracks
-                if (!isClone && videoTrackAdapter != null && track instanceof VideoTrack) {
+                // Clean up VideoTrackAdapter for video tracks (each TrackPrivate, incl. clones, has its own)
+                if (videoTrackAdapter != null && track instanceof VideoTrack) {
                     videoTrackAdapter.removeDimensionDetector((VideoTrack) track);
+                    videoTrackAdapter.dispose();
                 }
 
                 /*

--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -99,6 +99,8 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         // by the PeerConnection instance (RtpReceivers, RtpSenders, etc.)
         peerConnection.dispose();
 
+        videoTrackAdapters.dispose();
+
         remoteStreamIds.clear();
         remoteStreams.clear();
         remoteTracks.clear();

--- a/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
+++ b/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
@@ -89,6 +89,10 @@ public class VideoTrackAdapter {
         Log.d(TAG, "Deleted dimension detector for " + trackId);
     }
 
+    void dispose() {
+        timer.cancel();
+    }
+
     /**
      * Implements 'mute'/'unmute' events for remote video tracks through
      * the {@link VideoSink} interface.

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -144,8 +144,12 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 getUserMediaImpl.disposeAllTracks();
 
                 // 3. Dispose local streams
-                for (MediaStream stream : localStreams.values()) {
-                    stream.dispose();
+                for (Map.Entry<String, MediaStream> entry : localStreams.entrySet()) {
+                    try {
+                        entry.getValue().dispose();
+                    } catch (Exception e) {
+                        Log.w(TAG, "invalidate(): error disposing stream " + entry.getKey(), e);
+                    }
                 }
                 localStreams.clear();
 

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -124,6 +124,46 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         getUserMediaImpl = new GetUserMediaImpl(this, reactContext);
     }
 
+    @Override
+    public void invalidate() {
+        Log.d(TAG, "invalidate()");
+
+        try {
+            ThreadUtils.submitToExecutor(() -> {
+                // 1. Dispose PeerConnections (dispose() calls close() internally)
+                for (int i = 0; i < mPeerConnectionObservers.size(); i++) {
+                    try {
+                        mPeerConnectionObservers.valueAt(i).dispose();
+                    } catch (Exception e) {
+                        Log.w(TAG, "invalidate(): error disposing PC " + mPeerConnectionObservers.keyAt(i), e);
+                    }
+                }
+                mPeerConnectionObservers.clear();
+
+                // 2. Stop capturers + dispose tracks (prevents use-after-free on factory threads)
+                getUserMediaImpl.disposeAllTracks();
+
+                // 3. Dispose local streams
+                for (MediaStream stream : localStreams.values()) {
+                    stream.dispose();
+                }
+                localStreams.clear();
+
+                // 4. Dispose factory (frees C++ factory + 3 threads)
+                if (mFactory != null) {
+                    mFactory.dispose();
+                    mFactory = null;
+                }
+
+                return null;
+            }).get();
+        } catch (InterruptedException | ExecutionException e) {
+            Log.e(TAG, "invalidate() error", e);
+        }
+
+        super.invalidate();
+    }
+
     private JavaAudioDeviceModule createAudioDeviceModule(ReactApplicationContext reactContext) {
         speechActivityDetector = new SpeechActivityDetector(new SpeechActivityDetector.Listener() {
             @Override

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -140,18 +140,21 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 }
                 mPeerConnectionObservers.clear();
 
-                // 2. Stop capturers + dispose tracks (prevents use-after-free on factory threads)
-                getUserMediaImpl.disposeAllTracks();
-
-                // 3. Dispose local streams
+                // 2. Detach tracks, then dispose streams. Tracks themselves get disposed in step 3.
                 for (Map.Entry<String, MediaStream> entry : localStreams.entrySet()) {
                     try {
-                        entry.getValue().dispose();
+                        MediaStream stream = entry.getValue();
+                        for (AudioTrack t : new ArrayList<>(stream.audioTracks)) stream.removeTrack(t);
+                        for (VideoTrack t : new ArrayList<>(stream.videoTracks)) stream.removeTrack(t);
+                        stream.dispose();
                     } catch (Exception e) {
                         Log.w(TAG, "invalidate(): error disposing stream " + entry.getKey(), e);
                     }
                 }
                 localStreams.clear();
+
+                // 3. Stop capturers + dispose tracks (prevents use-after-free on factory threads)
+                getUserMediaImpl.disposeAllTracks();
 
                 // 4. Dispose factory (frees C++ factory + 3 threads)
                 if (mFactory != null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.1.4-alpha.6",
+  "version": "137.1.4-alpha.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "137.1.4-alpha.6",
+      "version": "137.1.4-alpha.7",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.1.4-alpha.7",
+  "version": "137.1.4-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "137.1.4-alpha.7",
+      "version": "137.1.4-alpha.8",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.1.4-alpha.5",
+  "version": "137.1.4-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "137.1.4-alpha.5",
+      "version": "137.1.4-alpha.6",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.1.4-alpha.6",
+  "version": "137.1.4-alpha.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.1.4-alpha.7",
+  "version": "137.1.4-alpha.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.1.4-alpha.5",
+  "version": "137.1.4-alpha.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"


### PR DESCRIPTION
* PeerConnectionFactory on Android wraps a C++ pointer via JNI. The Java wrapper has no finalize() — GC reclaims the Java object but the native factory and its 3 threads (network/worker/signaling) leak on every bridge reload. In this PR. we add the teardown for native factory on bridge reload. 
* iOS is unaffected — RTCPeerConnectionFactory uses unique_ptr C++ members that auto-destruct when ARC releases the ObjC object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown cleanup to fully dispose media tracks, streams, and adapters, reducing memory leaks and stopping periodic adapter timers.
  * Prevented screen-sharing from starting after the module has been disposed, returning a clear error instead.
  * Strengthened error handling and logging around synchronous cleanup to avoid silent failures.

* **Chores**
  * Bumped package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->