### PR TITLE
feat: handle lifecycle on android video effects

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -119,9 +119,11 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         // Find target camera to switch to.
         String[] deviceNames = cameraEnumerator.getDeviceNames();
 
-        // Use the initial deviceId/facingMode. It is a constraint violation to change these through applyConstraints.
-        final String deviceId = constraintDeviceId;
-        final String facingMode = constraintFacingMode;
+        // Re-read from the incoming constraints so `MediaStreamTrack._switchCamera()`
+        // can flip the camera via `applyConstraints({facingMode})` — the documented
+        // W3C pattern that browsers also implement.
+        final String deviceId = ReactBridgeUtil.getMapStrValue(constraints, "deviceId");
+        final String facingMode = ReactBridgeUtil.getMapStrValue(constraints, "facingMode");
         int cameraIndex = -1;
         String cameraName = null;
 

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -584,6 +584,11 @@ public class GetUserMediaImpl {
             VideoSource videoSource = (VideoSource) track.mediaSource;
             SurfaceTextureHelper surfaceTextureHelper = track.surfaceTextureHelper;
 
+            // Swap first, dispose last — otherwise a frame in flight could hit a freed
+            // processor. onCapturerStopped can't replace this; it also fires on pauses.
+            VideoEffectProcessor previousProcessor = track.videoEffectProcessor;
+            track.videoEffectProcessor = null;
+
             if (names != null) {
                 List<VideoFrameProcessor> processors =
                         names.toArrayList()
@@ -602,9 +607,14 @@ public class GetUserMediaImpl {
 
                 VideoEffectProcessor videoEffectProcessor = new VideoEffectProcessor(processors, surfaceTextureHelper);
                 videoSource.setVideoProcessor(videoEffectProcessor);
+                track.videoEffectProcessor = videoEffectProcessor;
 
             } else {
                 videoSource.setVideoProcessor(null);
+            }
+
+            if (previousProcessor != null) {
+                previousProcessor.dispose();
             }
         }
     }
@@ -642,6 +652,9 @@ public class GetUserMediaImpl {
          * The {@code VideoTrackAdapter} for dimension detection if {@link #track} is a {@link VideoTrack}.
          */
         public final VideoTrackAdapter videoTrackAdapter;
+
+        /** Current effect processor, disposed on filter switch and on track teardown. */
+        public VideoEffectProcessor videoEffectProcessor;
 
         /**
          * Whether this object has been disposed or not.
@@ -691,6 +704,13 @@ public class GetUserMediaImpl {
                     if (videoCaptureController.stopCapture()) {
                         videoCaptureController.dispose();
                     }
+                }
+
+                // After stopCapture so no frame can still reach it; before
+                // surfaceTextureHelper dispose so GL is still alive for cleanup.
+                if (!isClone && videoEffectProcessor != null) {
+                    videoEffectProcessor.dispose();
+                    videoEffectProcessor = null;
                 }
 
                 // Clean up VideoTrackAdapter for video tracks (each TrackPrivate, incl. clones, has its own)

--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
@@ -30,9 +30,8 @@ public class VideoEffectProcessor implements VideoProcessor {
 
     /**
      * Disposes each wrapped processor. Posted to the capturer handler so it runs
-     * after any in-flight {@link #onFrameCaptured}, letting implementations release
-     * GL resources inline. Idempotent. Called by the owner — not wired to
-     * {@link #onCapturerStopped}, which also fires on pauses.
+     * after any in-flight frame, so implementations can clean up GL state inline.
+     * Idempotent. Not wired to {@link #onCapturerStopped} because that also fires on pause.
      */
     public void dispose() {
         textureHelper.getHandler().post(() -> {

--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
@@ -15,6 +15,7 @@ public class VideoEffectProcessor implements VideoProcessor {
     private VideoSink mSink;
     final private SurfaceTextureHelper textureHelper;
     final private List<VideoFrameProcessor> videoFrameProcessors;
+    private boolean disposed = false;
 
     public VideoEffectProcessor(List<VideoFrameProcessor> processors, SurfaceTextureHelper textureHelper) {
         this.textureHelper = textureHelper;
@@ -26,6 +27,22 @@ public class VideoEffectProcessor implements VideoProcessor {
 
     @Override
     public void onCapturerStopped() {}
+
+    /**
+     * Disposes each wrapped processor. Posted to the capturer handler so it runs
+     * after any in-flight {@link #onFrameCaptured}, letting implementations release
+     * GL resources inline. Idempotent. Called by the owner — not wired to
+     * {@link #onCapturerStopped}, which also fires on pauses.
+     */
+    public void dispose() {
+        textureHelper.getHandler().post(() -> {
+            if (disposed) return;
+            disposed = true;
+            for (VideoFrameProcessor processor : this.videoFrameProcessors) {
+                processor.dispose();
+            }
+        });
+    }
 
     @Override
     public void setSink(VideoSink sink) {

--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoFrameProcessor.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoFrameProcessor.java
@@ -16,4 +16,10 @@ public interface VideoFrameProcessor {
      * @return processed videoframe which will rendered
      */
     public VideoFrame process(VideoFrame frame, SurfaceTextureHelper textureHelper);
+
+    /**
+     * Called once when this processor leaves the pipeline. Release any native or
+     * GL resources here. Runs on the capturer handler. Default no-op.
+     */
+    default void dispose() {}
 }

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -161,6 +161,32 @@
 - (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError {
     BOOL hasChanged = NO;
 
+    // Re-read device-selecting constraints so `MediaStreamTrack._switchCamera()`
+    // can flip the camera via `applyConstraints({facingMode})` — the documented
+    // W3C pattern that browsers also implement.
+    NSString *deviceId = constraints[@"deviceId"];
+    id facingMode = constraints[@"facingMode"];
+
+    BOOL targetFront = self.usingFrontCamera;
+    if ([facingMode isKindOfClass:[NSString class]]) {
+        if ([facingMode isEqualToString:@"environment"]) {
+            targetFront = NO;
+        } else if ([facingMode isEqualToString:@"user"]) {
+            targetFront = YES;
+        }
+    }
+    if (targetFront != self.usingFrontCamera) {
+        self.usingFrontCamera = targetFront;
+        // Clear deviceId so `startCapture` re-resolves it from the new position.
+        self.deviceId = nil;
+        hasChanged = YES;
+    }
+
+    if (deviceId && ![deviceId isEqualToString:self.deviceId]) {
+        self.deviceId = deviceId;
+        hasChanged = YES;
+    }
+
     int width = [constraints[@"width"] intValue];
     int height = [constraints[@"height"] intValue];
     int frameRate = [constraints[@"frameRate"] intValue];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.2.0-alpha.3",
+  "version": "137.2.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "137.2.0-alpha.3",
+      "version": "137.2.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.2.0-alpha.4",
+  "version": "137.2.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stream-io/react-native-webrtc",
-      "version": "137.2.0-alpha.4",
+      "version": "137.2.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.2.0-alpha.3",
+  "version": "137.2.0-alpha.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stream-io/react-native-webrtc",
-  "version": "137.2.0-alpha.4",
+  "version": "137.2.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GetStream/react-native-webrtc.git"


### PR DESCRIPTION
## Add lifecycle to video-effect processors on Android

VideoFrameProcessor implementations that hold native or GL resources had no way to release them: VideoEffectProcessor was only ever replaced or dropped, never torn down. Long-running sessions that switched filters leaked every previous processor's resources.

### Changes

- VideoFrameProcessor: new default void dispose() — default no-op keeps existing implementations compiling.
- VideoEffectProcessor: owns a dispose() that iterates its wrapped processors. Posted to the capturer handler so it's serialized with onFrameCaptured; idempotent.
- GetUserMediaImpl:
  - setVideoEffects now disposes the previous processor after swapping in the new one (swap first, dispose last — a frame in flight must not hit a freed processor).
  - TrackPrivate.dispose disposes the attached processor after stopCapture() returns and before SurfaceTextureHelper is disposed (GL context still alive).

Why not wire it to VideoProcessor.onCapturerStopped? That also fires on temporary pauses (camera disable / backgrounding) where the same processor is reused on resume — we'd dispose state the processor still needs.

### Test plan

- Switch filters repeatedly on a live call — no leaks, no crashes.
- Background/foreground the app mid-call — filter keeps working on resume (no accidental dispose).
- End the call / dispose the track — downstream processors' dispose() is called exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video effects lifecycle and cleanup to prevent memory leaks and improve stability during video processing.
  * Camera selection now respects updated deviceId/facingMode constraints at apply time, enabling more reliable camera switching when constraints change.
* **Chores**
  * Package version bumped to 137.2.0-alpha.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->