### PR TITLE
feat: support 'maintain-framerate-and-resolution' degradation preference

### DIFF
--- a/src/RTCRtpSendParameters.ts
+++ b/src/RTCRtpSendParameters.ts
@@ -4,6 +4,7 @@ import { deepClone } from './RTCUtil';
 
 type DegradationPreferenceType = 'maintain-framerate'
     | 'maintain-resolution'
+    | 'maintain-framerate-and-resolution'
     | 'balanced'
     | 'disabled'
 
@@ -14,13 +15,13 @@ type DegradationPreferenceType = 'maintain-framerate'
  */
 class DegradationPreference {
     static fromNative(nativeFormat: string): DegradationPreferenceType {
-        const stringFormat = nativeFormat.toLowerCase().replace('_', '-');
+        const stringFormat = nativeFormat.toLowerCase().replace(/_/g, '-');
 
         return stringFormat as DegradationPreferenceType;
     }
 
     static toNative(format: DegradationPreferenceType): string {
-        return format.toUpperCase().replace('-', '_');
+        return format.toUpperCase().replace(/-/g, '_');
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `'maintain-framerate-and-resolution'` to `DegradationPreferenceType`
- Fix `toNative` / `fromNative` to use global regex replaces (the existing single-replace was a latent bug for any multi-dash token)

## ⚠️ DO NOT MERGE before the M145 native SDK bump

`MAINTAIN_FRAMERATE_AND_RESOLUTION` first lands in libwebrtc with Chrome M144 ([Intent to Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/FUlvv_Lmk-s)).
This SDK currently pins M137 on both platforms:

- iOS: `StreamWebRTC ~> 137.0.54`
- Android: `io.getstream:stream-video-webrtc-android:137.0.1`

On M137, passing the new value will reject the JS promise on Android (`IllegalArgumentException` from `RtpParameters.DegradationPreference.valueOf`) and silently no-op on iOS. Wait until the pending M145 native SDK bump is published before merging this PR.

No native (iOS / Android) changes are needed: Android's `valueOf` and iOS's plain NSString assignment will both work once the underlying binary ships the new enum value.