### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -9,6 +9,10 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   android-compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   android-compile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: Simple CI
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   run-ci:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [pull_request]
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   run-ci:

--- a/.github/workflows/ios_ci.yml
+++ b/.github/workflows/ios_ci.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   actions: write
   contents: read
-  pull-requests: read
 
 jobs:
   ios-compile:

--- a/.github/workflows/ios_ci.yml
+++ b/.github/workflows/ios_ci.yml
@@ -9,6 +9,11 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   ios-compile:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **3** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [x] CI green
- [x] Code scanning alerts close after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow security by explicitly limiting workflow permissions.
  * Updated Android, iOS, and general CI workflows with clearer access controls.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->